### PR TITLE
Add configure Pages step to deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- run the official configure-pages action before building so the deploy action has the metadata it expects

## Testing
- CI=true npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da3bdbfa388325aedd29996efa2d6e