### PR TITLE
Fix asset paths for GitHub Pages deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  base: '/Codex-cute-game/',
   build: {
     target: 'es2022',
   },


### PR DESCRIPTION
## Summary
- configure the Vite base path so built assets load correctly when the site is served from the Codex-cute-game subdirectory on GitHub Pages

## Testing
- npm test *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dab4a582488325b8f3205fb0c29d6f