### PR TITLE
Update docs to reference Mischief Cat

### DIFF
--- a/docs/development_checklist.md
+++ b/docs/development_checklist.md
@@ -1,6 +1,6 @@
-# Aurora Glade Adventure Development Checklist
+# Mischief Cat Development Checklist
 
-This checklist tracks milestones and granular tasks for building the "Aurora Glade Adventure" third-person cute exploratory-action game in Three.js. Use it as a living document—check off items as work progresses and add dates/owners to keep the team aligned.
+This checklist tracks milestones and granular tasks for building the "Mischief Cat" third-person cute exploratory-action game in Three.js. Use it as a living document—check off items as work progresses and add dates/owners to keep the team aligned.
 
 ## 1. Vision & Planning
 - [ ] Define high-level elevator pitch and emotional pillars.

--- a/docs/game_design_document.md
+++ b/docs/game_design_document.md
@@ -1,4 +1,4 @@
-# Aurora Glade Adventure — Game Design Document
+# Mischief Cat — Game Design Document
 
 ## Table of Contents
 1. [Vision Statement](#vision-statement)


### PR DESCRIPTION
## Summary
- rename the game design document heading to use the Mischief Cat title
- update the development checklist heading and description to reference Mischief Cat instead of Aurora Glade Adventure

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dab8f522688325bc12b849bf2e39d6