### PR TITLE
Rebuild cat player with expressive rig

### DIFF
--- a/src/core/app.ts
+++ b/src/core/app.ts
@@ -30,6 +30,7 @@ export class App {
   private readonly catMesh: THREE.Group;
   private readonly player: number;
   private lastTime = 0;
+  private frameDelta = 0;
   private running = false;
   private cameraYaw = Math.PI * 0.8;
 
@@ -68,6 +69,7 @@ export class App {
       const now = performance.now() / 1000;
       const delta = now - this.lastTime;
       this.lastTime = now;
+      this.frameDelta = delta;
       updateInput(this.world, this.keyboard);
       this.time.advance(delta, (step) => this.step(step));
       this.updateCamera();
@@ -99,12 +101,13 @@ export class App {
   private updateCamera(): void {
     const transform = this.world.get(this.player, 'transform');
     if (!transform) return;
+    const physics = this.world.get(this.player, 'physics');
     const target = transform.position.clone();
     const offset = new THREE.Vector3(Math.sin(this.cameraYaw) * 6, 3.6, Math.cos(this.cameraYaw) * 6);
     const desired = target.clone().add(offset);
     this.camera.position.lerp(desired, 0.12);
     this.camera.lookAt(target.x, target.y + 0.5, target.z);
-    syncCatMesh(transform, this.catMesh);
+    syncCatMesh(transform, physics, this.catMesh, this.frameDelta);
   }
 
   private render(): void {

--- a/src/scene/actors.ts
+++ b/src/scene/actors.ts
@@ -14,31 +14,338 @@ import {
 } from '../ecs/components';
 import { World } from '../ecs/world';
 
-const CAT_COLOR = 0xffcc88;
+const CAT_COLOR = 0xffc795;
+const CAT_ACCENT = 0xffb286;
+const CAT_BELLY = 0xffe7d1;
+const CAT_DARK = 0x3a261c;
+const CAT_STRIPE = 0xd8875a;
+
+interface LegRigData {
+  root: THREE.Group;
+  lower: THREE.Group;
+  baseRoot: number;
+  baseLower: number;
+}
+
+interface CatRigData {
+  headPivot: THREE.Group;
+  headBaseY: number;
+  headBaseRotX: number;
+  tail: THREE.Group[];
+  tailBaseRotations: number[];
+  frontLeftLeg: LegRigData;
+  frontRightLeg: LegRigData;
+  backLeftLeg: LegRigData;
+  backRightLeg: LegRigData;
+  whiskers: [THREE.Mesh, THREE.Mesh];
+  whiskerBaseRot: number;
+  ears: [THREE.Group, THREE.Group];
+  earBaseRot: number;
+  time: number;
+}
+
+function createLeg(material: THREE.Material, pawMaterial: THREE.Material, options: {
+  upperLength: number;
+  lowerLength: number;
+  upperRadiusTop: number;
+  upperRadiusBottom: number;
+  lowerRadiusTop: number;
+  lowerRadiusBottom: number;
+}): LegRigData {
+  const root = new THREE.Group();
+  const upper = new THREE.Mesh(
+    new THREE.CylinderGeometry(options.upperRadiusTop, options.upperRadiusBottom, options.upperLength, 14, 1, false),
+    material,
+  );
+  upper.position.y = -options.upperLength / 2;
+  upper.castShadow = true;
+  root.add(upper);
+
+  const lower = new THREE.Group();
+  lower.position.y = -options.upperLength;
+  root.add(lower);
+
+  const lowerMesh = new THREE.Mesh(
+    new THREE.CylinderGeometry(options.lowerRadiusTop, options.lowerRadiusBottom, options.lowerLength, 12, 1, false),
+    material,
+  );
+  lowerMesh.position.y = -options.lowerLength / 2;
+  lowerMesh.castShadow = true;
+  lower.add(lowerMesh);
+
+  const ankle = new THREE.Group();
+  ankle.position.y = -options.lowerLength * 0.98;
+  lower.add(ankle);
+
+  const paw = new THREE.Mesh(new THREE.SphereGeometry(0.09, 16, 12), pawMaterial);
+  paw.scale.set(1.4, 0.6, 1.8);
+  paw.position.y = -0.06;
+  paw.castShadow = true;
+  ankle.add(paw);
+
+  root.castShadow = true;
+  lower.castShadow = true;
+
+  return {
+    root,
+    lower,
+    baseRoot: 0,
+    baseLower: 0,
+  };
+}
 
 function createCatMesh(): THREE.Group {
   const group = new THREE.Group();
-  const body = new THREE.Mesh(new THREE.CapsuleGeometry(0.25, 0.6, 12, 16), new THREE.MeshStandardMaterial({ color: CAT_COLOR }));
+  const furMaterial = new THREE.MeshStandardMaterial({ color: CAT_COLOR, roughness: 0.65, metalness: 0.08 });
+  const accentMaterial = new THREE.MeshStandardMaterial({ color: CAT_ACCENT, roughness: 0.6, metalness: 0.05 });
+  const bellyMaterial = new THREE.MeshStandardMaterial({ color: CAT_BELLY, roughness: 0.85, metalness: 0.02 });
+  const darkMaterial = new THREE.MeshStandardMaterial({ color: CAT_DARK, roughness: 0.5, metalness: 0.08 });
+  const stripeMaterial = new THREE.MeshStandardMaterial({ color: CAT_STRIPE, roughness: 0.55, metalness: 0.04 });
+
+  const body = new THREE.Mesh(new THREE.CapsuleGeometry(0.26, 0.76, 20, 28), furMaterial);
+  body.rotation.z = Math.PI / 2;
+  body.position.set(0, 0.44, -0.02);
   body.castShadow = true;
   group.add(body);
-  const head = new THREE.Mesh(new THREE.SphereGeometry(0.22, 16, 12), new THREE.MeshStandardMaterial({ color: CAT_COLOR }));
-  head.position.set(0, 0.55, 0.2);
+
+  const chest = new THREE.Mesh(new THREE.SphereGeometry(0.28, 24, 18), furMaterial);
+  chest.scale.set(0.75, 0.58, 0.9);
+  chest.position.set(0, 0.46, 0.14);
+  chest.castShadow = true;
+  group.add(chest);
+
+  const haunch = new THREE.Mesh(new THREE.SphereGeometry(0.32, 24, 18), furMaterial);
+  haunch.scale.set(0.78, 0.62, 1.04);
+  haunch.position.set(0, 0.42, -0.34);
+  haunch.castShadow = true;
+  group.add(haunch);
+
+  const belly = new THREE.Mesh(new THREE.CapsuleGeometry(0.18, 0.58, 16, 20), bellyMaterial);
+  belly.rotation.z = Math.PI / 2;
+  belly.position.set(0, 0.34, -0.02);
+  belly.castShadow = false;
+  group.add(belly);
+
+  const stripeRidgeGeo = new THREE.CylinderGeometry(0.08, 0.11, 0.32, 10, 1, true);
+  stripeRidgeGeo.rotateX(Math.PI / 2);
+  const stripeRidge = new THREE.Mesh(stripeRidgeGeo, stripeMaterial);
+  stripeRidge.position.set(0, 0.44, -0.12);
+  stripeRidge.scale.set(1, 1, 1.1);
+  group.add(stripeRidge);
+
+  const collar = new THREE.Mesh(new THREE.TorusGeometry(0.22, 0.03, 12, 24), accentMaterial);
+  collar.rotation.x = Math.PI / 2;
+  collar.position.set(0, 0.57, 0.16);
+  collar.castShadow = true;
+  group.add(collar);
+
+  const headPivot = new THREE.Group();
+  headPivot.position.set(0, 0.66, 0.18);
+  group.add(headPivot);
+
+  const head = new THREE.Mesh(new THREE.SphereGeometry(0.22, 26, 20), furMaterial);
+  head.position.set(0, 0, 0.12);
   head.castShadow = true;
-  group.add(head);
-  const earGeo = new THREE.ConeGeometry(0.12, 0.2, 8);
-  const earMat = new THREE.MeshStandardMaterial({ color: 0xffaa77 });
-  const leftEar = new THREE.Mesh(earGeo, earMat);
-  leftEar.position.set(-0.16, 0.78, 0.08);
-  leftEar.rotation.z = Math.PI / 8;
-  group.add(leftEar);
-  const rightEar = leftEar.clone();
-  rightEar.position.x = 0.16;
-  rightEar.rotation.z = -Math.PI / 8;
-  group.add(rightEar);
-  const tail = new THREE.Mesh(new THREE.CylinderGeometry(0.07, 0.07, 0.6, 10), new THREE.MeshStandardMaterial({ color: 0xffbb88 }));
-  tail.position.set(0, 0.2, -0.35);
-  tail.rotation.x = Math.PI / 2.5;
-  group.add(tail);
+  headPivot.add(head);
+
+  const cheekGeo = new THREE.SphereGeometry(0.12, 18, 14);
+  const leftCheek = new THREE.Mesh(cheekGeo, furMaterial);
+  leftCheek.position.set(-0.12, -0.02, 0.14);
+  leftCheek.scale.set(0.9, 0.8, 1.1);
+  const rightCheek = leftCheek.clone();
+  rightCheek.position.x = 0.12;
+  headPivot.add(leftCheek, rightCheek);
+
+  const muzzle = new THREE.Mesh(new THREE.SphereGeometry(0.13, 18, 14), bellyMaterial);
+  muzzle.position.set(0, -0.05, 0.26);
+  muzzle.scale.set(1.2, 0.7, 1.4);
+  headPivot.add(muzzle);
+
+  const mouth = new THREE.Mesh(new THREE.TorusGeometry(0.07, 0.008, 8, 24, Math.PI), darkMaterial);
+  mouth.rotation.set(Math.PI / 2, 0, 0);
+  mouth.position.set(0, -0.09, 0.32);
+  headPivot.add(mouth);
+
+  const nose = new THREE.Mesh(new THREE.ConeGeometry(0.035, 0.08, 14), accentMaterial);
+  nose.position.set(0, -0.02, 0.35);
+  nose.rotation.x = Math.PI;
+  headPivot.add(nose);
+
+  const eyeGeo = new THREE.SphereGeometry(0.05, 16, 14);
+  const irisMat = new THREE.MeshStandardMaterial({ color: 0x224255, emissive: 0x0b1e26, emissiveIntensity: 0.45 });
+  const pupilMat = new THREE.MeshStandardMaterial({ color: 0x081012, emissive: 0x0a1113, emissiveIntensity: 0.3 });
+  const leftEye = new THREE.Mesh(eyeGeo, irisMat);
+  leftEye.scale.set(1, 1.2, 0.65);
+  leftEye.position.set(-0.09, 0.03, 0.24);
+  const rightEye = leftEye.clone();
+  rightEye.position.x = 0.09;
+  headPivot.add(leftEye, rightEye);
+
+  const pupilGeo = new THREE.SphereGeometry(0.022, 12, 10);
+  const leftPupil = new THREE.Mesh(pupilGeo, pupilMat);
+  leftPupil.scale.set(1, 1.8, 0.5);
+  leftPupil.position.set(-0.09, 0.03, 0.28);
+  const rightPupil = leftPupil.clone();
+  rightPupil.position.x = 0.09;
+  headPivot.add(leftPupil, rightPupil);
+
+  const eyebrowGeo = new THREE.BoxGeometry(0.12, 0.02, 0.02);
+  const eyebrowMat = new THREE.MeshStandardMaterial({ color: CAT_DARK, roughness: 0.6 });
+  const leftBrow = new THREE.Mesh(eyebrowGeo, eyebrowMat);
+  leftBrow.position.set(-0.09, 0.12, 0.2);
+  leftBrow.rotation.z = Math.PI * 0.08;
+  const rightBrow = leftBrow.clone();
+  rightBrow.position.x = 0.09;
+  rightBrow.rotation.z = -Math.PI * 0.08;
+  headPivot.add(leftBrow, rightBrow);
+
+  const whiskerGeo = new THREE.BoxGeometry(0.28, 0.008, 0.01);
+  const whiskerMat = new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.4 });
+  const leftWhisker = new THREE.Mesh(whiskerGeo, whiskerMat);
+  leftWhisker.position.set(-0.17, -0.03, 0.32);
+  leftWhisker.rotation.y = Math.PI * 0.04;
+  const rightWhisker = leftWhisker.clone();
+  rightWhisker.position.x = 0.17;
+  rightWhisker.rotation.y = -Math.PI * 0.04;
+  headPivot.add(leftWhisker, rightWhisker);
+
+  const earOuterGeo = new THREE.ConeGeometry(0.13, 0.26, 14);
+  const earInnerGeo = new THREE.ConeGeometry(0.09, 0.2, 14);
+  const earOuterMat = new THREE.MeshStandardMaterial({ color: CAT_COLOR, roughness: 0.6 });
+  const earInnerMat = new THREE.MeshStandardMaterial({ color: CAT_ACCENT, roughness: 0.55 });
+
+  function createEar(sign: 1 | -1): THREE.Group {
+    const earPivot = new THREE.Group();
+    earPivot.position.set(0.12 * sign, 0.17, 0.02);
+    earPivot.rotation.z = sign * Math.PI * 0.18;
+    const outer = new THREE.Mesh(earOuterGeo, earOuterMat);
+    outer.position.y = 0.13;
+    outer.castShadow = true;
+    earPivot.add(outer);
+    const inner = new THREE.Mesh(earInnerGeo, earInnerMat);
+    inner.position.y = 0.11;
+    inner.scale.set(0.82, 0.82, 0.82);
+    earPivot.add(inner);
+    return earPivot;
+  }
+
+  const leftEar = createEar(-1);
+  const rightEar = createEar(1);
+  headPivot.add(leftEar, rightEar);
+
+  const pawMaterial = new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.82, metalness: 0.01 });
+  const frontLeftLeg = createLeg(furMaterial, pawMaterial, {
+    upperLength: 0.32,
+    lowerLength: 0.28,
+    upperRadiusTop: 0.08,
+    upperRadiusBottom: 0.09,
+    lowerRadiusTop: 0.07,
+    lowerRadiusBottom: 0.08,
+  });
+  frontLeftLeg.root.position.set(-0.18, 0.47, 0.18);
+  const frontRightLeg = createLeg(furMaterial, pawMaterial, {
+    upperLength: 0.32,
+    lowerLength: 0.28,
+    upperRadiusTop: 0.08,
+    upperRadiusBottom: 0.09,
+    lowerRadiusTop: 0.07,
+    lowerRadiusBottom: 0.08,
+  });
+  frontRightLeg.root.position.set(0.18, 0.47, 0.18);
+  const backLeftLeg = createLeg(furMaterial, pawMaterial, {
+    upperLength: 0.34,
+    lowerLength: 0.32,
+    upperRadiusTop: 0.09,
+    upperRadiusBottom: 0.11,
+    lowerRadiusTop: 0.08,
+    lowerRadiusBottom: 0.1,
+  });
+  backLeftLeg.root.position.set(-0.2, 0.45, -0.28);
+  const backRightLeg = createLeg(furMaterial, pawMaterial, {
+    upperLength: 0.34,
+    lowerLength: 0.32,
+    upperRadiusTop: 0.09,
+    upperRadiusBottom: 0.11,
+    lowerRadiusTop: 0.08,
+    lowerRadiusBottom: 0.1,
+  });
+  backRightLeg.root.position.set(0.2, 0.45, -0.28);
+
+  frontLeftLeg.baseRoot = -0.3;
+  frontRightLeg.baseRoot = -0.3;
+  backLeftLeg.baseRoot = -0.36;
+  backRightLeg.baseRoot = -0.36;
+  frontLeftLeg.baseLower = 0.35;
+  frontRightLeg.baseLower = 0.35;
+  backLeftLeg.baseLower = 0.45;
+  backRightLeg.baseLower = 0.45;
+
+  frontLeftLeg.root.rotation.x = frontLeftLeg.baseRoot;
+  frontRightLeg.root.rotation.x = frontRightLeg.baseRoot;
+  backLeftLeg.root.rotation.x = backLeftLeg.baseRoot;
+  backRightLeg.root.rotation.x = backRightLeg.baseRoot;
+  frontLeftLeg.lower.rotation.x = frontLeftLeg.baseLower;
+  frontRightLeg.lower.rotation.x = frontRightLeg.baseLower;
+  backLeftLeg.lower.rotation.x = backLeftLeg.baseLower;
+  backRightLeg.lower.rotation.x = backRightLeg.baseLower;
+
+  group.add(frontLeftLeg.root, frontRightLeg.root, backLeftLeg.root, backRightLeg.root);
+
+  const tailBase = new THREE.Group();
+  tailBase.position.set(0, 0.52, -0.46);
+  tailBase.rotation.x = Math.PI * 0.36;
+  group.add(tailBase);
+
+  const tailSegment1 = new THREE.Mesh(new THREE.CylinderGeometry(0.06, 0.085, 0.32, 12), furMaterial);
+  tailSegment1.position.y = 0.16;
+  tailSegment1.castShadow = true;
+  tailBase.add(tailSegment1);
+
+  const tailMid = new THREE.Group();
+  tailMid.position.y = 0.32;
+  tailSegment1.add(tailMid);
+  tailMid.rotation.x = Math.PI * 0.05;
+
+  const tailSegment2 = new THREE.Mesh(new THREE.CylinderGeometry(0.05, 0.06, 0.32, 12), furMaterial);
+  tailSegment2.position.y = 0.16;
+  tailSegment2.castShadow = true;
+  tailMid.add(tailSegment2);
+
+  const tailTip = new THREE.Group();
+  tailTip.position.y = 0.32;
+  tailSegment2.add(tailTip);
+  tailTip.rotation.x = Math.PI * 0.02;
+
+  const tailSegment3 = new THREE.Mesh(new THREE.CylinderGeometry(0.04, 0.03, 0.3, 12), accentMaterial);
+  tailSegment3.position.y = 0.15;
+  tailSegment3.castShadow = true;
+  tailTip.add(tailSegment3);
+
+  const tailStripeGeo = new THREE.CylinderGeometry(0.045, 0.045, 0.1, 10, 1, true);
+  tailStripeGeo.rotateX(Math.PI / 2);
+  const tailStripe = new THREE.Mesh(tailStripeGeo, darkMaterial);
+  tailStripe.position.set(0, 0.14, 0);
+  tailSegment3.add(tailStripe);
+
+  const rig: CatRigData = {
+    headPivot,
+    headBaseY: headPivot.position.y,
+    headBaseRotX: headPivot.rotation.x,
+    tail: [tailBase, tailMid, tailTip],
+    tailBaseRotations: [tailBase.rotation.x, tailMid.rotation.x, tailTip.rotation.x],
+    frontLeftLeg,
+    frontRightLeg,
+    backLeftLeg,
+    backRightLeg,
+    whiskers: [leftWhisker, rightWhisker],
+    whiskerBaseRot: leftWhisker.rotation.y,
+    ears: [leftEar, rightEar],
+    earBaseRot: leftEar.rotation.x,
+    time: Math.random() * Math.PI * 2,
+  };
+
+  group.userData.cat = rig;
+
   return group;
 }
 

--- a/src/systems/playerController.ts
+++ b/src/systems/playerController.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { PlayerController, Transform } from '../ecs/components';
+import { PhysicsBody, PlayerController, Transform } from '../ecs/components';
 import { World } from '../ecs/world';
 
 const forward = new THREE.Vector3();
@@ -56,8 +56,77 @@ export function updatePlayer(world: World, delta: number, cameraYaw: number): vo
   });
 }
 
-export function syncCatMesh(transform: Transform, mesh: THREE.Object3D): void {
+export function syncCatMesh(
+  transform: Transform,
+  physics: PhysicsBody | undefined,
+  mesh: THREE.Object3D,
+  delta: number,
+): void {
   mesh.position.copy(transform.position);
-  mesh.position.y += 0.2;
+  mesh.position.y += 0.18;
   mesh.rotation.y = transform.rotationY;
+
+  const rig = mesh.userData.cat as
+    | {
+        headPivot: THREE.Group;
+        headBaseY: number;
+        headBaseRotX: number;
+        tail: THREE.Group[];
+        tailBaseRotations: number[];
+        frontLeftLeg: { root: THREE.Group; lower: THREE.Group; baseRoot: number; baseLower: number };
+        frontRightLeg: { root: THREE.Group; lower: THREE.Group; baseRoot: number; baseLower: number };
+        backLeftLeg: { root: THREE.Group; lower: THREE.Group; baseRoot: number; baseLower: number };
+        backRightLeg: { root: THREE.Group; lower: THREE.Group; baseRoot: number; baseLower: number };
+        whiskers: [THREE.Mesh, THREE.Mesh];
+        whiskerBaseRot: number;
+        ears: [THREE.Group, THREE.Group];
+        earBaseRot: number;
+        time: number;
+      }
+    | undefined;
+  if (!rig) return;
+
+  const speed = physics ? Math.sqrt(physics.velocity.x ** 2 + physics.velocity.z ** 2) : 0;
+  const moveStrength = Math.min(speed / 4.4, 1);
+  const idleStrength = Math.max(0.2, moveStrength * 0.85);
+  rig.time += delta * (3.4 + moveStrength * 5.6);
+
+  const stride = rig.time * 3.2;
+  const frontSwing = Math.sin(stride) * 0.55 * moveStrength;
+  const frontOpposite = Math.sin(stride + Math.PI) * 0.55 * moveStrength;
+  const backSwing = Math.sin(stride + Math.PI) * 0.65 * moveStrength;
+  const backOpposite = Math.sin(stride) * 0.65 * moveStrength;
+
+  const kneeBend = (phase: number) => Math.max(0, Math.sin(phase + Math.PI / 2)) * 0.55 * moveStrength;
+
+  rig.frontLeftLeg.root.rotation.x = rig.frontLeftLeg.baseRoot + frontSwing;
+  rig.frontRightLeg.root.rotation.x = rig.frontRightLeg.baseRoot + frontOpposite;
+  rig.backLeftLeg.root.rotation.x = rig.backLeftLeg.baseRoot + backSwing * 0.9;
+  rig.backRightLeg.root.rotation.x = rig.backRightLeg.baseRoot + backOpposite * 0.9;
+
+  rig.frontLeftLeg.lower.rotation.x = rig.frontLeftLeg.baseLower + kneeBend(stride + Math.PI);
+  rig.frontRightLeg.lower.rotation.x = rig.frontRightLeg.baseLower + kneeBend(stride);
+  rig.backLeftLeg.lower.rotation.x = rig.backLeftLeg.baseLower + kneeBend(stride + Math.PI) * 1.2;
+  rig.backRightLeg.lower.rotation.x = rig.backRightLeg.baseLower + kneeBend(stride) * 1.2;
+
+  const headBob = Math.sin(rig.time * 2.1) * 0.04 * (0.3 + idleStrength);
+  const headPitch = Math.sin(rig.time * 1.6) * 0.12 * (0.4 + idleStrength * 0.8);
+  rig.headPivot.position.y = rig.headBaseY + headBob;
+  rig.headPivot.rotation.x = rig.headBaseRotX + headPitch;
+  rig.headPivot.rotation.y = Math.sin(rig.time * 1.5) * 0.08 * idleStrength;
+
+  rig.tail[0].rotation.x = rig.tailBaseRotations[0] + Math.cos(rig.time * 1.4) * 0.12 * idleStrength;
+  rig.tail[0].rotation.y = Math.sin(rig.time * 1.3) * 0.28 * idleStrength;
+  rig.tail[1].rotation.x = rig.tailBaseRotations[1] + Math.sin(rig.time * 1.8 + 0.6) * 0.18 * idleStrength;
+  rig.tail[1].rotation.y = Math.sin(rig.time * 1.7 + Math.PI / 3) * 0.18 * idleStrength;
+  rig.tail[2].rotation.x = rig.tailBaseRotations[2] + Math.sin(rig.time * 2.4 + 1.2) * 0.22 * idleStrength;
+  rig.tail[2].rotation.y = Math.sin(rig.time * 2.2 + Math.PI / 2) * 0.24 * idleStrength;
+
+  const whiskerOffset = Math.sin(rig.time * 2.3) * 0.22 * (0.4 + idleStrength);
+  rig.whiskers[0].rotation.y = rig.whiskerBaseRot + whiskerOffset;
+  rig.whiskers[1].rotation.y = -rig.whiskerBaseRot - whiskerOffset;
+
+  const earFlick = Math.sin(rig.time * 2.7) * 0.1 * (0.3 + idleStrength);
+  rig.ears[0].rotation.x = rig.earBaseRot + earFlick;
+  rig.ears[1].rotation.x = rig.earBaseRot - earFlick;
 }


### PR DESCRIPTION
## Summary
- rebuild the cat player mesh with layered body volumes, detailed face, and articulated limbs for a feline silhouette
- update the cat rig to animate multi-jointed legs, tail segments, ears, and whiskers for livelier motion
- refresh fur materials and accents to give the player avatar a cuter presentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dab909af708325b555e414718a57eb