### PR TITLE
Fix cat mesh orientation and animation

### DIFF
--- a/src/scene/actors.ts
+++ b/src/scene/actors.ts
@@ -103,7 +103,7 @@ function createCatMesh(): THREE.Group {
   const stripeMaterial = new THREE.MeshStandardMaterial({ color: CAT_STRIPE, roughness: 0.55, metalness: 0.04 });
 
   const body = new THREE.Mesh(new THREE.CapsuleGeometry(0.26, 0.76, 20, 28), furMaterial);
-  body.rotation.z = Math.PI / 2;
+  body.rotation.x = Math.PI / 2;
   body.position.set(0, 0.44, -0.02);
   body.castShadow = true;
   group.add(body);
@@ -121,7 +121,7 @@ function createCatMesh(): THREE.Group {
   group.add(haunch);
 
   const belly = new THREE.Mesh(new THREE.CapsuleGeometry(0.18, 0.58, 16, 20), bellyMaterial);
-  belly.rotation.z = Math.PI / 2;
+  belly.rotation.x = Math.PI / 2;
   belly.position.set(0, 0.34, -0.02);
   belly.castShadow = false;
   group.add(belly);
@@ -293,7 +293,7 @@ function createCatMesh(): THREE.Group {
 
   const tailBase = new THREE.Group();
   tailBase.position.set(0, 0.52, -0.46);
-  tailBase.rotation.x = Math.PI * 0.36;
+  tailBase.rotation.x = -Math.PI * 0.48;
   group.add(tailBase);
 
   const tailSegment1 = new THREE.Mesh(new THREE.CylinderGeometry(0.06, 0.085, 0.32, 12), furMaterial);

--- a/src/systems/playerController.ts
+++ b/src/systems/playerController.ts
@@ -87,17 +87,17 @@ export function syncCatMesh(
   if (!rig) return;
 
   const speed = physics ? Math.sqrt(physics.velocity.x ** 2 + physics.velocity.z ** 2) : 0;
-  const moveStrength = Math.min(speed / 4.4, 1);
-  const idleStrength = Math.max(0.2, moveStrength * 0.85);
-  rig.time += delta * (3.4 + moveStrength * 5.6);
+  const moveStrength = Math.min(speed / 4.2, 1);
+  const idleStrength = THREE.MathUtils.clamp(0.24 + moveStrength * 0.56, 0.24, 1);
+  rig.time += delta * (2.8 + moveStrength * 4.4);
 
-  const stride = rig.time * 3.2;
-  const frontSwing = Math.sin(stride) * 0.55 * moveStrength;
-  const frontOpposite = Math.sin(stride + Math.PI) * 0.55 * moveStrength;
-  const backSwing = Math.sin(stride + Math.PI) * 0.65 * moveStrength;
-  const backOpposite = Math.sin(stride) * 0.65 * moveStrength;
+  const stride = rig.time * (2.6 + moveStrength * 0.6);
+  const frontSwing = Math.sin(stride) * 0.45 * moveStrength;
+  const frontOpposite = Math.sin(stride + Math.PI) * 0.45 * moveStrength;
+  const backSwing = Math.sin(stride + Math.PI) * 0.55 * moveStrength;
+  const backOpposite = Math.sin(stride) * 0.55 * moveStrength;
 
-  const kneeBend = (phase: number) => Math.max(0, Math.sin(phase + Math.PI / 2)) * 0.55 * moveStrength;
+  const kneeBend = (phase: number) => Math.max(0, Math.sin(phase + Math.PI / 2)) * 0.45 * moveStrength;
 
   rig.frontLeftLeg.root.rotation.x = rig.frontLeftLeg.baseRoot + frontSwing;
   rig.frontRightLeg.root.rotation.x = rig.frontRightLeg.baseRoot + frontOpposite;
@@ -109,20 +109,20 @@ export function syncCatMesh(
   rig.backLeftLeg.lower.rotation.x = rig.backLeftLeg.baseLower + kneeBend(stride + Math.PI) * 1.2;
   rig.backRightLeg.lower.rotation.x = rig.backRightLeg.baseLower + kneeBend(stride) * 1.2;
 
-  const headBob = Math.sin(rig.time * 2.1) * 0.04 * (0.3 + idleStrength);
-  const headPitch = Math.sin(rig.time * 1.6) * 0.12 * (0.4 + idleStrength * 0.8);
+  const headBob = Math.sin(rig.time * 1.9) * 0.035 * (0.4 + idleStrength * 0.6);
+  const headPitch = Math.sin(rig.time * 1.4) * 0.09 * (0.45 + idleStrength * 0.6);
   rig.headPivot.position.y = rig.headBaseY + headBob;
   rig.headPivot.rotation.x = rig.headBaseRotX + headPitch;
   rig.headPivot.rotation.y = Math.sin(rig.time * 1.5) * 0.08 * idleStrength;
 
-  rig.tail[0].rotation.x = rig.tailBaseRotations[0] + Math.cos(rig.time * 1.4) * 0.12 * idleStrength;
-  rig.tail[0].rotation.y = Math.sin(rig.time * 1.3) * 0.28 * idleStrength;
-  rig.tail[1].rotation.x = rig.tailBaseRotations[1] + Math.sin(rig.time * 1.8 + 0.6) * 0.18 * idleStrength;
-  rig.tail[1].rotation.y = Math.sin(rig.time * 1.7 + Math.PI / 3) * 0.18 * idleStrength;
-  rig.tail[2].rotation.x = rig.tailBaseRotations[2] + Math.sin(rig.time * 2.4 + 1.2) * 0.22 * idleStrength;
-  rig.tail[2].rotation.y = Math.sin(rig.time * 2.2 + Math.PI / 2) * 0.24 * idleStrength;
+  rig.tail[0].rotation.x = rig.tailBaseRotations[0] + Math.cos(rig.time * 1.2) * 0.1 * idleStrength;
+  rig.tail[0].rotation.y = Math.sin(rig.time * 1.1) * 0.22 * idleStrength;
+  rig.tail[1].rotation.x = rig.tailBaseRotations[1] + Math.sin(rig.time * 1.6 + 0.6) * 0.16 * idleStrength;
+  rig.tail[1].rotation.y = Math.sin(rig.time * 1.5 + Math.PI / 3) * 0.16 * idleStrength;
+  rig.tail[2].rotation.x = rig.tailBaseRotations[2] + Math.sin(rig.time * 2.1 + 1.2) * 0.18 * idleStrength;
+  rig.tail[2].rotation.y = Math.sin(rig.time * 1.9 + Math.PI / 2) * 0.2 * idleStrength;
 
-  const whiskerOffset = Math.sin(rig.time * 2.3) * 0.22 * (0.4 + idleStrength);
+  const whiskerOffset = Math.sin(rig.time * 2.0) * 0.18 * (0.4 + idleStrength * 0.8);
   rig.whiskers[0].rotation.y = rig.whiskerBaseRot + whiskerOffset;
   rig.whiskers[1].rotation.y = -rig.whiskerBaseRot - whiskerOffset;
 


### PR DESCRIPTION
## Summary
- align the cat body and belly meshes with the forward axis and reorient the tail base so the silhouette matches the design
- tune the leg, head, tail, and whisker animation curves to feel more natural at idle and while moving

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dacb6692f883259b8a3e41e204fe92