### PR TITLE
Export cat rig types for reuse

### DIFF
--- a/src/scene/actors.ts
+++ b/src/scene/actors.ts
@@ -20,14 +20,14 @@ const CAT_BELLY = 0xffe7d1;
 const CAT_DARK = 0x3a261c;
 const CAT_STRIPE = 0xd8875a;
 
-interface LegRigData {
+export interface LegRigData {
   root: THREE.Group;
   lower: THREE.Group;
   baseRoot: number;
   baseLower: number;
 }
 
-interface CatRigData {
+export interface CatRigData {
   headPivot: THREE.Group;
   headBaseY: number;
   headBaseRotX: number;

--- a/src/systems/playerController.ts
+++ b/src/systems/playerController.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { PhysicsBody, PlayerController, Transform } from '../ecs/components';
+import type { CatRigData } from '../scene/actors';
 import { World } from '../ecs/world';
 
 const forward = new THREE.Vector3();
@@ -66,24 +67,7 @@ export function syncCatMesh(
   mesh.position.y += 0.18;
   mesh.rotation.y = transform.rotationY;
 
-  const rig = mesh.userData.cat as
-    | {
-        headPivot: THREE.Group;
-        headBaseY: number;
-        headBaseRotX: number;
-        tail: THREE.Group[];
-        tailBaseRotations: number[];
-        frontLeftLeg: { root: THREE.Group; lower: THREE.Group; baseRoot: number; baseLower: number };
-        frontRightLeg: { root: THREE.Group; lower: THREE.Group; baseRoot: number; baseLower: number };
-        backLeftLeg: { root: THREE.Group; lower: THREE.Group; baseRoot: number; baseLower: number };
-        backRightLeg: { root: THREE.Group; lower: THREE.Group; baseRoot: number; baseLower: number };
-        whiskers: [THREE.Mesh, THREE.Mesh];
-        whiskerBaseRot: number;
-        ears: [THREE.Group, THREE.Group];
-        earBaseRot: number;
-        time: number;
-      }
-    | undefined;
+  const rig = mesh.userData.cat as CatRigData | undefined;
   if (!rig) return;
 
   const speed = physics ? Math.sqrt(physics.velocity.x ** 2 + physics.velocity.z ** 2) : 0;


### PR DESCRIPTION
## Summary
- export the cat rig data types so they can be reused outside the cat actor module
- update the player controller to rely on the shared cat rig type instead of an inline structural type

## Testing
- npm test -- --run
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc11c256dc8325a5b3da4a0a2d5e1c